### PR TITLE
Fix public services multizone asset paths

### DIFF
--- a/dashboard/react-dashboard/package.json
+++ b/dashboard/react-dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "uk-public-services-dashboard",
   "version": "1.0.0",
   "description": "Interactive dashboard for UK public services spending analysis",
+  "homepage": "/uk/public-services-spending",
   "private": true,
   "dependencies": {
     "react": "^18.2.0",

--- a/dashboard/react-dashboard/src/components/ChartTab.js
+++ b/dashboard/react-dashboard/src/components/ChartTab.js
@@ -3,6 +3,7 @@ import Plot from 'react-plotly.js';
 
 const LIGHT_BG = '#FFFFFF';
 const DARK_TEXT = '#1D4044';
+const BASE_PATH = process.env.PUBLIC_URL || '';
 
 function ChartTab({ title, description, dataFile, xAxisTitle, yAxisTitle, colors, compact = false, horizontal = false, leftMargin = null }) {
   const [data, setData] = useState(null);
@@ -13,7 +14,7 @@ function ChartTab({ title, description, dataFile, xAxisTitle, yAxisTitle, colors
     setLoading(true);
     setError(null);
 
-    fetch(`/data/${dataFile}`)
+    fetch(`${BASE_PATH}/data/${dataFile}`)
       .then(response => {
         if (!response.ok) {
           throw new Error(`Failed to load data: ${response.statusText}`);

--- a/dashboard/react-dashboard/src/components/UKMapTab.js
+++ b/dashboard/react-dashboard/src/components/UKMapTab.js
@@ -3,6 +3,7 @@ import Plot from 'react-plotly.js';
 
 const LIGHT_BG = '#FFFFFF';
 const DARK_TEXT = '#1D4044';
+const BASE_PATH = process.env.PUBLIC_URL || '';
 
 // Region coordinates (approximate centers) and display names
 const REGION_INFO = {
@@ -30,7 +31,7 @@ function UKMapTab({ title, description, compact = false }) {
     setLoading(true);
     setError(null);
 
-    fetch('/data/by_region.json')
+    fetch(`${BASE_PATH}/data/by_region.json`)
       .then(response => {
         if (!response.ok) {
           throw new Error(`Failed to load data: ${response.statusText}`);

--- a/dashboard/react-dashboard/vercel.json
+++ b/dashboard/react-dashboard/vercel.json
@@ -4,6 +4,14 @@
   "framework": "create-react-app",
   "rewrites": [
     {
+      "source": "/uk/public-services-spending/static/:path*",
+      "destination": "/static/:path*"
+    },
+    {
+      "source": "/uk/public-services-spending/data/:path*",
+      "destination": "/data/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- set the React dashboard homepage to /uk/public-services-spending so built CSS/JS URLs use the mounted path
- prefix runtime data fetches with PUBLIC_URL
- add Vercel rewrites for prefixed static and data assets back to the CRA build output

## Verification
- CI=true npm test -- --watchAll=false --passWithNoTests
- npm run build
- inspected build/index.html and bundle output for /uk/public-services-spending/static and /uk/public-services-spending/data paths