### PR TITLE
Import @policyengine/ui-kit/theme.css for brand tokens

### DIFF
--- a/dashboard/react-dashboard/app/globals.css
+++ b/dashboard/react-dashboard/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@policyengine/ui-kit/theme.css";
 @import "../node_modules/@policyengine/ui-kit/dist/styles.css";
 
 /*


### PR DESCRIPTION
PolicyEngineShell header uses `--color-teal-*` and `--spacing-header` from theme.css. Without these tokens the gradient renders blank.